### PR TITLE
issue #6 - split "ansi" interpolator into conditional and unconditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ And color tags:
 [error]                          ^
 ```
 
-# Disable ansi codes at runtime when they are not supported
+# Conditional ANSI codes rendering / Non-ANSI terminals support
 
-Set the environment variable `conditional-ansi-support` to `yes` at compile time
-to produce code that will detect at runtime ansi support (or lack thereof, e.g windows).
+Use `ansiCond"..."` instead of `ansi"..."` to generate code that detects ANSI support (or lack thereof, e.g log files or windows terminal) at runtime.
+If ANSI support isn't detected the `ansiCond` interpolator will output a plain text.
+
+```scala
+ansiCond"%red{Hello}, I'm logs and windows %bold{friendly}"
+```

--- a/src/main/scala/org/backuity/ansi/AnsiFormatter.scala
+++ b/src/main/scala/org/backuity/ansi/AnsiFormatter.scala
@@ -10,11 +10,18 @@ object AnsiFormatter {
   implicit class FormattedHelper(val sc: StringContext) extends AnyVal {
 
     def ansi(args: Any*): String = macro ansiImpl
+    def ansiCond(args: Any*): String = macro ansiCondImpl
   }
 
-  val conditionalAnsiSupport = !sys.env.getOrElse("conditional-ansi-support", "").equals("")
-
   def ansiImpl(c: blackbox.Context)(args: c.Tree*) = {
+    gencode(conditionalAnsiSupport = false)(c)(args)
+  }
+
+  def ansiCondImpl(c: blackbox.Context)(args: c.Tree*) = {
+    gencode(conditionalAnsiSupport = true)(c)(args)
+  }
+
+  private def gencode(conditionalAnsiSupport: Boolean)(c: blackbox.Context)(args: Seq[c.Tree]) = {
     import c.universe._
 
     val Apply(_, List(Apply(_, partsTree))) = c.prefix.tree


### PR DESCRIPTION
Added another string interpolator `ansiCond` that replaces `conditional-ansi-support` as proposed here - https://github.com/backuity/ansi-interpolator/pull/6#issuecomment-825588810
